### PR TITLE
Update serial_link_4759.py

### DIFF
--- a/serial_link_4759.py
+++ b/serial_link_4759.py
@@ -151,20 +151,6 @@ def find_name(keyword, files):
     print('-'*12)
 
 
-def wait_msg(ser):
-  # before recive wait
-  s = ser.inWaiting()
-  while ser.inWaiting() == s:
-    time.sleep(0.1)
-
-  # receiving wait
-  dif = True
-  while dif:
-    s = ser.inWaiting()
-    time.sleep(0.1)
-    dif = (s < ser.inWaiting())
-
-
 def send_cmd(cmd, ser, silent=False):
   # send command
   ser.reset_input_buffer()
@@ -175,7 +161,7 @@ def send_cmd(cmd, ser, silent=False):
 def print_recv(ser, silent=False):
   # get response (& print)
   msg = ''
-  wait_msg(ser)
+  time.sleep(0.5)
   while ser.inWaiting() > 0:
     msg += ser.read().decode('utf-8')
   if not silent:


### PR DESCRIPTION
通信が不安定な場合にフリーズしてしまうので、受信前のwait処理を取りやめた。